### PR TITLE
Fix the build on ASDF 3.3

### DIFF
--- a/cl-secure-read.asd
+++ b/cl-secure-read.asd
@@ -1,26 +1,17 @@
 ;;;; cl-secure-read.asd
 
-(in-package asdf)
-
-(asdf:defsystem #:cl-secure-read
+(defsystem "cl-secure-read"
   :serial t
   :description "Secure lisp reader in spirit of Let over Lambda"
   :author "Alexander Popolitov <popolit@gmail.com>"
   :license "GPLv3"
-  :depends-on (#:defmacro-enhance #:rutils #:named-readtables #:iterate #:yaclanapht #:alexandria)
+  :depends-on ("defmacro-enhance" "rutils" "named-readtables" "iterate" "yaclanapht" "alexandria")
   :components ((:file "package")
-               (:file "cl-secure-read")))
+               (:file "cl-secure-read"))
+  :in-order-to ((test-op (test-op "cl-secure-read/tests"))))
 
-(asdf:defsystem #:cl-secure-read-tests
-  :depends-on (#:cl-secure-read #:fiveam)
+(defsystem "cl-secure-read/tests"
+  :depends-on ("cl-secure-read" "fiveam")
   :licence "GPLv3"
-  :components ((:file "tests")))
-
-(defmethod perform ((o asdf:test-op) (c (eql (asdf:find-system :cl-secure-read))))
-  (operate 'load-op :cl-secure-read-tests :force t)
-  (operate 'test-op :cl-secure-read-tests :force t))
-
-(defmethod perform ((o asdf:test-op) (c (eql (asdf:find-system :cl-secure-read-tests))))
-  (load-system :cl-secure-read-tests)
-  (funcall (intern "RUN-TESTS" :cl-secure-read-tests)))
-
+  :components ((:file "tests"))
+  :perform (test-op (o c) (symbol-call :cl-secure-read-tests :run-tests)))

--- a/cl-secure-read.lisp
+++ b/cl-secure-read.lisp
@@ -65,8 +65,8 @@ NAME is the name of a function, which is used in the error report."
 			  (expand-white-black-list ,e!-it)
 			  (analyze-readtable-chars rt)))
 	  (whitelist (expand-white-black-list ,whitelist)))
-     (let ((,g!-errfun-name (lambda (stream close-char)
-			      (declare (ignore stream close-char))
+     (let ((,g!-errfun-name (lambda (stream close-char &optional arg)
+			      (declare (ignore stream close-char arg))
 			      (error ,(strcat (string name) " failure")))))
        ;; Disable ordinary macro-chars
        (let ((black-macro-chars (cdr (assoc :macro-chars blacklist)))

--- a/tests.lisp
+++ b/tests.lisp
@@ -52,10 +52,10 @@
   (mv-equal (funcall strict-lambda "#.(+ 1 2 3)") "caboom!")
   (mv-equal (funcall strict-lambda "; this is the comment") "caboom!")
   (mv-equal (funcall strict-lambda "#(1 2 3)") "caboom!"))
-  
 
-;; ;;; Here we test DEFINE-SECURE-READ  
-			
+
+;; ;;; Here we test DEFINE-SECURE-READ
+
 (define-secure-read strict-secure-read :fail-value "caboom!")
 
 (test stream-strict
@@ -75,7 +75,3 @@
             "caboom!")
   (mv-equal (less-strict-secure-read (make-string-input-stream "; this is the comment")) "caboom!")
   (mv-equal (vector-to-list (less-strict-secure-read (make-string-input-stream "#(1 2 3)"))) (1 2 3)))
-
-
-  
-			


### PR DESCRIPTION
Fix the asd file to make ASDF happy and follow modern conventions.

Fix the error function to optionally accept the extra argument passed to
dispatch macro characters functions (since it is used in two contexts).

PS: There are still 4 test failures.